### PR TITLE
fix: re-export all json-schema as readonly types

### DIFF
--- a/lib/basic.test.ts
+++ b/lib/basic.test.ts
@@ -4,7 +4,9 @@ import type { BasicFromJSONSchema } from './basic';
 
 describe('check scalar definitions', (): void => {
   it('boolean works', (): void => {
-    const value: BasicFromJSONSchema<{ type: 'boolean' }> = true;
+    const schema = { type: 'boolean' } as const;
+    type S = typeof schema;
+    const value: BasicFromJSONSchema<S> = true;
     type Expected = boolean;
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
@@ -12,7 +14,9 @@ describe('check scalar definitions', (): void => {
   });
 
   it('null works', (): void => {
-    const value: BasicFromJSONSchema<{ type: 'null' }> = null;
+    const schema = { type: 'null' } as const;
+    type S = typeof schema;
+    const value: BasicFromJSONSchema<S> = null;
     type Expected = null;
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
@@ -20,7 +24,9 @@ describe('check scalar definitions', (): void => {
   });
 
   it('integer works', (): void => {
-    const value: BasicFromJSONSchema<{ type: 'integer' }> = 1;
+    const schema = { type: 'integer' } as const;
+    type S = typeof schema;
+    const value: BasicFromJSONSchema<S> = 1;
     type Expected = number;
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
@@ -28,7 +34,9 @@ describe('check scalar definitions', (): void => {
   });
 
   it('number works', (): void => {
-    const value: BasicFromJSONSchema<{ type: 'number' }> = 1;
+    const schema = { type: 'number' } as const;
+    type S = typeof schema;
+    const value: BasicFromJSONSchema<S> = 1;
     type Expected = number;
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
@@ -36,7 +44,9 @@ describe('check scalar definitions', (): void => {
   });
 
   it('string works', (): void => {
-    const value: BasicFromJSONSchema<{ type: 'string' }> = 'hello';
+    const schema = { type: 'string' } as const;
+    type S = typeof schema;
+    const value: BasicFromJSONSchema<S> = 'hello';
     type Expected = string;
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
@@ -47,19 +57,47 @@ describe('check scalar definitions', (): void => {
 describe('check defined values definitions', (): void => {
   it('const works', (): void => {
     // note value type must be '1' and not 'number'!
-    const value: BasicFromJSONSchema<{ const: 1; type: 'number' }> = 1;
+    const schema = { const: 1, type: 'number' } as const;
+    type S = typeof schema;
+    const value: BasicFromJSONSchema<S> = 1;
     type Expected = 1;
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
     expect(value).toBe(check);
   });
 
+  it('const array works', (): void => {
+    const schema = { const: [1, 2] } as const;
+    type S = typeof schema;
+    // note value type must be '1' and not 'number'!
+    const value: BasicFromJSONSchema<S> = [1, 2] as const;
+    type Expected = readonly [1, 2];
+    type T = typeof value extends Expected ? Expected : never;
+    const check: T = value;
+    expect(value).toBe(check);
+  });
+
   it('enum works', (): void => {
-    const value: BasicFromJSONSchema<{
-      enum: [1, 'hello'];
-      type: 'string';
-    }> = 'hello';
+    const schema = {
+      enum: [1, 'hello'],
+      type: 'string',
+    } as const;
+    type S = typeof schema;
+    const value: BasicFromJSONSchema<S> = 'hello';
     type Expected = 1 | 'hello';
+    type T = typeof value extends Expected ? Expected : never;
+    const check: T = value;
+    expect(value).toBe(check);
+  });
+
+  it('enum of complex data works', (): void => {
+    const schema = {
+      enum: [[1, 2], 'hello'],
+      type: 'string',
+    } as const;
+    type S = typeof schema;
+    const value: BasicFromJSONSchema<S> = [1, 2] as const;
+    type Expected = readonly [1, 2] | 'hello';
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
     expect(value).toBe(check);

--- a/lib/basic.ts
+++ b/lib/basic.ts
@@ -1,4 +1,4 @@
-import type { JSONSchema7Type } from 'json-schema';
+import { JSONSchema7Type } from './json-schema';
 
 export type BooleanJSONSchemaType = 'boolean';
 export type NullJSONSchemaType = 'null';
@@ -26,7 +26,7 @@ export type ScalarFromJSONSchema<
   : never;
 
 export type ConstJSONSchema = { const: JSONSchema7Type };
-export type EnumJSONSchema = { enum: JSONSchema7Type[] };
+export type EnumJSONSchema = { enum: readonly JSONSchema7Type[] };
 
 export type DefinedValueJSONSchema = ConstJSONSchema | EnumJSONSchema;
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 import schemas from './common-schemas';
 import helpers from './schema-helpers';
 
+export * from './json-schema';
 export * from './types';
 
 export const commonSchemas = schemas;

--- a/lib/json-schema.ts
+++ b/lib/json-schema.ts
@@ -1,0 +1,24 @@
+// Redeclare 'json-schema' in a `as const` friendly way
+
+import type {
+  JSONSchema7 as RWJSONSchema7,
+  JSONSchema7Definition as RWJSONSchema7Definition,
+  JSONSchema7Object as RWJSONSchema7Object,
+  JSONSchema7Type as RWJSONSchema7Type,
+} from 'json-schema';
+
+export type DeepReadonly<T> = T extends
+  | boolean
+  | number
+  | string
+  | null
+  | undefined
+  ? T
+  : T extends Array<infer U>
+  ? ReadonlyArray<DeepReadonly<U>>
+  : { readonly [P in keyof T]: DeepReadonly<T[P]> };
+
+export type JSONSchema7 = DeepReadonly<RWJSONSchema7>;
+export type JSONSchema7Definition = DeepReadonly<RWJSONSchema7Definition>;
+export type JSONSchema7Object = DeepReadonly<RWJSONSchema7Object>;
+export type JSONSchema7Type = DeepReadonly<RWJSONSchema7Type>;

--- a/lib/schema-helpers.test.ts
+++ b/lib/schema-helpers.test.ts
@@ -8,7 +8,7 @@ describe('schemaHelpers', (): void => {
       { pattern: '[a-z]' },
     );
     type Expected = {
-      allOf: [
+      readonly allOf: readonly [
         {
           maxItems: number;
           minItems: number;
@@ -29,12 +29,12 @@ describe('schemaHelpers', (): void => {
       { pattern: '[a-z]' },
     );
     type Expected = {
-      anyOf: [
+      readonly anyOf: readonly [
         {
-          maxItems: number;
-          minItems: number;
+          readonly maxItems: number;
+          readonly minItems: number;
         },
-        { pattern: string },
+        { readonly pattern: string },
       ];
     };
     type T = typeof value extends Expected ? Expected : never;
@@ -46,7 +46,7 @@ describe('schemaHelpers', (): void => {
 
   it('const works', (): void => {
     const value = schemaHelpers.const('apple');
-    type Expected = { const: 'apple' };
+    type Expected = { readonly const: 'apple' };
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
     expect(check).toEqual({ const: 'apple' });
@@ -54,7 +54,7 @@ describe('schemaHelpers', (): void => {
 
   it('enum works', (): void => {
     const value = schemaHelpers.enum('apple', 1);
-    type Expected = { enum: ['apple', 1] };
+    type Expected = { readonly enum: readonly ['apple', 1] };
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
     expect(check).toEqual({ enum: ['apple', 1] });
@@ -62,7 +62,11 @@ describe('schemaHelpers', (): void => {
 
   it('array works', (): void => {
     const value = schemaHelpers.array({ maxItems: 10, minItems: 1 });
-    type Expected = { maxItems: number; minItems: number; type: 'array' };
+    type Expected = {
+      readonly maxItems: number;
+      readonly minItems: number;
+      readonly type: 'array';
+    };
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
     expect(check).toEqual({
@@ -75,7 +79,10 @@ describe('schemaHelpers', (): void => {
   describe('number works', (): void => {
     it('multipleOf works (integer)', (): void => {
       const value = schemaHelpers.number.multipleOf(5, 'integer');
-      type Expected = { multipleOf: number; type: 'integer' };
+      type Expected = {
+        readonly multipleOf: number;
+        readonly type: 'integer';
+      };
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
       expect(check).toEqual({
@@ -85,7 +92,10 @@ describe('schemaHelpers', (): void => {
     });
     it('multipleOf works (default)', (): void => {
       const value = schemaHelpers.number.multipleOf(5);
-      type Expected = { multipleOf: number; type: 'number' };
+      type Expected = {
+        readonly multipleOf: number;
+        readonly type: 'number';
+      };
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
       expect(check).toEqual({
@@ -99,7 +109,11 @@ describe('schemaHelpers', (): void => {
         { maximum: 10, minimum: 1 },
         'integer',
       );
-      type Expected = { maximum: number; minimum: number; type: 'integer' };
+      type Expected = {
+        readonly maximum: number;
+        readonly minimum: number;
+        readonly type: 'integer';
+      };
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
       expect(check).toEqual({
@@ -140,7 +154,9 @@ describe('schemaHelpers', (): void => {
       commonSchemas.string,
       commonSchemas.number,
     );
-    type Expected = { oneOf: [{ type: 'string' }, { type: 'number' }] };
+    type Expected = {
+      readonly oneOf: readonly [{ type: 'string' }, { type: 'number' }];
+    };
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
     expect(check).toEqual({
@@ -150,7 +166,9 @@ describe('schemaHelpers', (): void => {
 
   it('orNull works', (): void => {
     const value = schemaHelpers.orNull(commonSchemas.string);
-    type Expected = { anyOf: [{ type: 'string' }, { type: 'null' }] };
+    type Expected = {
+      readonly anyOf: readonly [{ type: 'string' }, { type: 'null' }];
+    };
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
     expect(check).toEqual({
@@ -160,7 +178,7 @@ describe('schemaHelpers', (): void => {
 
   it('schema works', (): void => {
     const value = schemaHelpers.schema({ type: 'string' });
-    type Expected = { type: 'string' };
+    type Expected = { readonly type: 'string' };
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
     expect(check).toEqual({ type: 'string' });
@@ -169,7 +187,7 @@ describe('schemaHelpers', (): void => {
   describe('string works', (): void => {
     it('format works', (): void => {
       const value = schemaHelpers.string.format('uri');
-      type Expected = { type: 'string' };
+      type Expected = { readonly type: 'string' };
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
       expect(check).toEqual({ format: 'uri', type: 'string' });
@@ -180,7 +198,11 @@ describe('schemaHelpers', (): void => {
         maxLength: 10,
         minLength: 1,
       });
-      type Expected = { type: 'string'; maxLength: number; minLength: number };
+      type Expected = {
+        readonly type: 'string';
+        readonly maxLength: number;
+        readonly minLength: number;
+      };
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
       expect(check).toEqual({
@@ -193,7 +215,10 @@ describe('schemaHelpers', (): void => {
     describe('pattern works', (): void => {
       it('simple works', (): void => {
         const value = schemaHelpers.string.pattern('[a-z]+');
-        type Expected = { type: 'string'; pattern: string };
+        type Expected = {
+          readonly type: 'string';
+          readonly pattern: string;
+        };
         type T = typeof value extends Expected ? Expected : never;
         const check: T = value;
         expect(check).toEqual({ pattern: '[a-z]+', type: 'string' });
@@ -205,10 +230,10 @@ describe('schemaHelpers', (): void => {
           minLength: 1,
         });
         type Expected = {
-          type: 'string';
-          pattern: string;
-          maxLength: number;
-          minLength: number;
+          readonly type: 'string';
+          readonly pattern: string;
+          readonly maxLength: number;
+          readonly minLength: number;
         };
         type T = typeof value extends Expected ? Expected : never;
         const check: T = value;

--- a/lib/schema-helpers.ts
+++ b/lib/schema-helpers.ts
@@ -3,55 +3,55 @@ import type {
   JSONSchema7,
   JSONSchema7Definition,
   JSONSchema7Type,
-} from 'json-schema';
+} from './json-schema';
 
 import type { NumberJSONSchemaType } from './basic';
 
-type ArrayItemsParam = {
-  items?: JSONSchema7Definition | JSONSchema7Definition[];
+type ArrayItemsParam = Readonly<{
+  items?: JSONSchema7Definition | readonly JSONSchema7Definition[];
   additionalItems?: JSONSchema7Definition;
   maxItems?: number;
   minItems?: number;
   uniqueItems?: boolean;
   contains?: JSONSchema7;
-};
+}>;
 
-type NumberRangeParam = {
+type NumberRangeParam = Readonly<{
   exclusiveMaximum?: number;
   exclusiveMinimum?: number;
   maximum?: number;
   minimum?: number;
-};
+}>;
 
-type ObjectPropertiesParam = {
+type ObjectPropertiesParam = Readonly<{
   maxProperties?: number;
   minProperties?: number;
-  required?: string[];
+  required?: readonly string[];
   properties?: {
-    [key: string]: JSONSchema7Definition;
+    readonly [key: string]: JSONSchema7Definition;
   };
   patternProperties?: {
-    [key: string]: JSONSchema7Definition;
+    readonly [key: string]: JSONSchema7Definition;
   };
   additionalProperties?: JSONSchema7Definition;
   dependencies?: {
-    [key: string]: JSONSchema7Definition | string[];
+    readonly [key: string]: JSONSchema7Definition | readonly string[];
   };
   propertyNames?: JSONSchema7Definition;
-};
+}>;
 
-type StringLengthParam = {
+type StringLengthParam = Readonly<{
   maxLength?: number;
   minLength?: number;
-};
+}>;
 
 export default {
-  allOf: <T extends JSONSchema7Definition[]>(
+  allOf: <T extends readonly JSONSchema7Definition[]>(
     ...schemas: T
   ): Readonly<{ allOf: T }> => ({
     allOf: schemas,
   }),
-  anyOf: <T extends JSONSchema7Definition[]>(
+  anyOf: <T extends readonly JSONSchema7Definition[]>(
     ...schemas: T
   ): Readonly<{ anyOf: T }> => ({
     anyOf: schemas,
@@ -65,7 +65,7 @@ export default {
   const: <T extends JSONSchema7Type>(value: T): Readonly<{ const: T }> => ({
     const: value,
   }),
-  enum: <T extends JSONSchema7Type[]>(
+  enum: <T extends readonly JSONSchema7Type[]>(
     ...schemas: T
   ): Readonly<{ enum: T }> => ({
     enum: schemas,
@@ -95,14 +95,14 @@ export default {
     ...param,
     type: 'object',
   }),
-  oneOf: <T extends JSONSchema7Definition[]>(
+  oneOf: <T extends readonly JSONSchema7Definition[]>(
     ...schemas: T
   ): Readonly<{ oneOf: T }> => ({
     oneOf: schemas,
   }),
   orNull: <T extends JSONSchema7Definition>(
     schema: T,
-  ): Readonly<{ anyOf: [T, { type: 'null' }] }> => ({
+  ): Readonly<{ anyOf: readonly [T, { type: 'null' }] }> => ({
     anyOf: [schema, { type: 'null' }],
   }),
   schema: <T extends JSONSchema7>(schema: T): Readonly<T> => schema, // easy typing

--- a/lib/types.test.ts
+++ b/lib/types.test.ts
@@ -1,7 +1,6 @@
 // note this is more focused on TypeScript/tsc than Jest itself
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { JSONSchema7Object, JSONSchema7Type } from 'json-schema';
+import { JSONSchema7Object, JSONSchema7Type } from './json-schema';
 
 import type { TypeFromJSONSchema } from './index';
 
@@ -9,7 +8,9 @@ import type { TypeFromJSONSchema } from './index';
 describe('basic definitions', (): void => {
   describe('check scalar definitions', (): void => {
     it('boolean works', (): void => {
-      const value: TypeFromJSONSchema<{ type: 'boolean' }> = true;
+      const schema = { type: 'boolean' } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = true;
       type Expected = boolean;
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -17,7 +18,9 @@ describe('basic definitions', (): void => {
     });
 
     it('null works', (): void => {
-      const value: TypeFromJSONSchema<{ type: 'null' }> = null;
+      const schema = { type: 'null' } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = null;
       type Expected = null;
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -25,7 +28,9 @@ describe('basic definitions', (): void => {
     });
 
     it('integer works', (): void => {
-      const value: TypeFromJSONSchema<{ type: 'integer' }> = 1;
+      const schema = { type: 'integer' } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = 1;
       type Expected = number;
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -33,7 +38,9 @@ describe('basic definitions', (): void => {
     });
 
     it('number works', (): void => {
-      const value: TypeFromJSONSchema<{ type: 'number' }> = 1;
+      const schema = { type: 'number' } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = 1;
       type Expected = number;
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -41,7 +48,9 @@ describe('basic definitions', (): void => {
     });
 
     it('string works', (): void => {
-      const value: TypeFromJSONSchema<{ type: 'string' }> = 'hello';
+      const schema = { type: 'string' } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = 'hello';
       type Expected = string;
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -52,19 +61,47 @@ describe('basic definitions', (): void => {
   describe('check defined values definitions', (): void => {
     it('const works', (): void => {
       // note value type must be '1' and not 'number'!
-      const value: TypeFromJSONSchema<{ const: 1; type: 'number' }> = 1;
+      const schema = { const: 1, type: 'number' } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = 1;
       type Expected = 1;
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
       expect(value).toBe(check);
     });
 
+    it('const array works', (): void => {
+      const schema = { const: [1, 2] } as const;
+      type S = typeof schema;
+      // note value type must be '1' and not 'number'!
+      const value: TypeFromJSONSchema<S> = [1, 2] as const;
+      type Expected = readonly [1, 2];
+      type T = typeof value extends Expected ? Expected : never;
+      const check: T = value;
+      expect(value).toBe(check);
+    });
+
     it('enum works', (): void => {
-      const value: TypeFromJSONSchema<{
-        enum: [1, 'hello'];
-        type: 'string';
-      }> = 'hello';
+      const schema = {
+        enum: [1, 'hello'],
+        type: 'string',
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = 'hello';
       type Expected = 1 | 'hello';
+      type T = typeof value extends Expected ? Expected : never;
+      const check: T = value;
+      expect(value).toBe(check);
+    });
+
+    it('enum of complex data works', (): void => {
+      const schema = {
+        enum: [[1, 2], 'hello'],
+        type: 'string',
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = [1, 2] as const;
+      type Expected = readonly [1, 2] | 'hello';
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
       expect(value).toBe(check);
@@ -74,12 +111,14 @@ describe('basic definitions', (): void => {
 
 describe('combination definitions', (): void => {
   it('allOf works', (): void => {
-    const value: TypeFromJSONSchema<{
+    const schema = {
       allOf: [
-        { type: 'string'; minLength: 1 },
-        { type: 'string'; maxLength: 10 },
-      ];
-    }> = 'hello';
+        { minLength: 1, type: 'string' },
+        { maxLength: 10, type: 'string' },
+      ],
+    } as const;
+    type S = typeof schema;
+    const value: TypeFromJSONSchema<S> = 'hello';
     type Expected = string;
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
@@ -87,9 +126,11 @@ describe('combination definitions', (): void => {
   });
 
   it('anyOf works', (): void => {
-    const value: TypeFromJSONSchema<{
-      anyOf: [{ type: 'boolean' }, { type: 'string' }];
-    }> = true;
+    const schema = {
+      anyOf: [{ type: 'boolean' }, { type: 'string' }],
+    } as const;
+    type S = typeof schema;
+    const value: TypeFromJSONSchema<S> = true;
     type Expected = boolean | string;
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
@@ -97,9 +138,11 @@ describe('combination definitions', (): void => {
   });
 
   it('allOf works', (): void => {
-    const value: TypeFromJSONSchema<{
-      allOf: [{ type: 'boolean' }, { type: 'string' }];
-    }> = true;
+    const schema = {
+      allOf: [{ type: 'boolean' }, { type: 'string' }],
+    } as const;
+    type S = typeof schema;
+    const value: TypeFromJSONSchema<S> = true;
     type Expected = boolean | string;
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
@@ -108,7 +151,9 @@ describe('combination definitions', (): void => {
 
   describe('not works', (): void => {
     it('with basic type', (): void => {
-      const value: TypeFromJSONSchema<{ not: { type: 'boolean' } }> = 1;
+      const schema = { not: { type: 'boolean' } } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = 1;
       type Expected = Exclude<JSONSchema7Type, boolean>;
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -116,9 +161,11 @@ describe('combination definitions', (): void => {
     });
 
     it('with combination type', (): void => {
-      const value: TypeFromJSONSchema<{
-        not: { anyOf: [{ type: 'boolean' }, { type: 'string' }] };
-      }> = 1;
+      const schema = {
+        not: { anyOf: [{ type: 'boolean' }, { type: 'string' }] },
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = 1;
       type Expected = Exclude<JSONSchema7Type, boolean | string>;
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -126,9 +173,11 @@ describe('combination definitions', (): void => {
     });
 
     it('with container type', (): void => {
-      const value: TypeFromJSONSchema<{
-        not: { type: 'object'; properties: { a: { type: 'number' } } };
-      }> = 1;
+      const schema = {
+        not: { properties: { a: { type: 'number' } }, type: 'object' },
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = 1;
       type Expected = Exclude<JSONSchema7Type, boolean | string>;
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -137,9 +186,11 @@ describe('combination definitions', (): void => {
   });
 
   it('oneOf works', (): void => {
-    const value: TypeFromJSONSchema<{
-      oneOf: [{ type: 'boolean' }, { type: 'string' }];
-    }> = true;
+    const schema = {
+      oneOf: [{ type: 'boolean' }, { type: 'string' }],
+    } as const;
+    type S = typeof schema;
+    const value: TypeFromJSONSchema<S> = true;
     type Expected = boolean | string;
     type T = typeof value extends Expected ? Expected : never;
     const check: T = value;
@@ -150,10 +201,12 @@ describe('combination definitions', (): void => {
 describe('container definitions', (): void => {
   describe('array definitions', (): void => {
     it('homogeneous works', (): void => {
-      const value: TypeFromJSONSchema<{
-        type: 'array';
-        items: { type: 'boolean' };
-      }> = [true, false];
+      const schema = {
+        items: { type: 'boolean' },
+        type: 'array',
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = [true, false];
       type Expected = boolean[];
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -161,9 +214,9 @@ describe('container definitions', (): void => {
     });
 
     it('untyped homogeneous works', (): void => {
-      const value: TypeFromJSONSchema<{
-        type: 'array';
-      }> = [true, false];
+      const schema = { type: 'array' } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = [true, false];
       type Expected = JSONSchema7Type[];
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -171,10 +224,9 @@ describe('container definitions', (): void => {
     });
 
     it('untyped homogeneous works (items: true)', (): void => {
-      const value: TypeFromJSONSchema<{
-        type: 'array';
-        items: true;
-      }> = [true, false];
+      const schema = { items: true, type: 'array' } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = [true, false];
       type Expected = JSONSchema7Type[];
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -182,10 +234,12 @@ describe('container definitions', (): void => {
     });
 
     it('tuple works', (): void => {
-      const value: TypeFromJSONSchema<{
-        type: 'array';
-        items: [{ type: 'boolean' }, { type: 'string' }];
-      }> = [true, 'hello'];
+      const schema = {
+        items: [{ type: 'boolean' }, { type: 'string' }],
+        type: 'array',
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = [true, 'hello'];
       type Expected = [boolean, string];
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -193,10 +247,12 @@ describe('container definitions', (): void => {
     });
 
     it('untyped tuple works', (): void => {
-      const value: TypeFromJSONSchema<{
-        type: 'array';
-        items: [true, true];
-      }> = [true, 'hello'];
+      const schema = {
+        items: [true, true],
+        type: 'array',
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = [true, 'hello'];
       type Expected = [JSONSchema7Type, JSONSchema7Type];
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -206,14 +262,16 @@ describe('container definitions', (): void => {
 
   describe('object definitions', (): void => {
     it('defined properties works', (): void => {
-      const value: TypeFromJSONSchema<{
-        type: 'object';
+      const schema = {
         properties: {
-          a: { type: 'boolean' };
-          b: { type: 'string' };
-          c: { type: 'number' };
-        };
-      }> = {
+          a: { type: 'boolean' },
+          b: { type: 'string' },
+          c: { type: 'number' },
+        },
+        type: 'object',
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = {
         a: true,
         c: 1,
         d: [1], // extra properties are allowed
@@ -229,15 +287,21 @@ describe('container definitions', (): void => {
     });
 
     it('defined properties works with required properties', (): void => {
-      const value: TypeFromJSONSchema<{
-        type: 'object';
+      const schema = {
         properties: {
-          a: { type: 'boolean' };
-          b: { type: 'string' };
-          c: { type: 'number' };
-        };
-        required: ['a', 'c'];
-      }> = {
+          a: { type: 'boolean' },
+          b: { type: 'string' },
+          c: { type: 'number' },
+          t: {
+            items: [{ type: 'string' }, { type: 'boolean' }],
+            type: 'array',
+          },
+        },
+        required: ['a', 'c'],
+        type: 'object',
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = {
         a: true,
         c: 1,
         d: [1], // extra properties are allowed
@@ -246,6 +310,7 @@ describe('container definitions', (): void => {
         a: boolean;
         b?: string;
         c: number;
+        t?: [string, boolean];
       } & JSONSchema7Object;
       type T = typeof value extends Expected ? Expected : never;
       const check: T = value;
@@ -253,16 +318,18 @@ describe('container definitions', (): void => {
     });
 
     it('defined properties works with required properties and no additional properties', (): void => {
-      const value: TypeFromJSONSchema<{
-        type: 'object';
+      const schema = {
+        additionalProperties: false,
         properties: {
-          a: { type: 'boolean' };
-          b: { type: 'string' };
-          c: { type: 'number' };
-        };
-        required: ['a', 'c'];
-        additionalProperties: false;
-      }> = {
+          a: { type: 'boolean' },
+          b: { type: 'string' },
+          c: { type: 'number' },
+        },
+        required: ['a', 'c'],
+        type: 'object',
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = {
         a: true,
         c: 1,
       };
@@ -277,14 +344,16 @@ describe('container definitions', (): void => {
     });
 
     it('defined properties works with required properties and no additional number properties', (): void => {
-      const value: TypeFromJSONSchema<{
-        type: 'object';
+      const schema = {
+        additionalProperties: { type: 'number' },
         properties: {
-          a: { type: 'boolean' };
-        };
-        required: ['a'];
-        additionalProperties: { type: 'number' };
-      }> = {
+          a: { type: 'boolean' },
+        },
+        required: ['a'],
+        type: 'object',
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = {
         a: true,
         b: 1,
         c: 2,
@@ -304,13 +373,15 @@ describe('container definitions', (): void => {
     });
 
     it('pattern properties works', (): void => {
-      const value: TypeFromJSONSchema<{
-        type: 'object';
+      const schema = {
         patternProperties: {
-          ignoredKey: { type: 'boolean' };
-          otherKey: { type: 'string' };
-        };
-      }> = {
+          ignoredKey: { type: 'boolean' },
+          otherKey: { type: 'string' },
+        },
+        type: 'object',
+      } as const;
+      type S = typeof schema;
+      const value: TypeFromJSONSchema<S> = {
         a: true,
         b: 'hello',
       };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,7 +3,7 @@ import type {
   JSONSchema7Definition,
   JSONSchema7Object,
   JSONSchema7Type,
-} from 'json-schema';
+} from './json-schema';
 
 import type { BasicJSONSchema, BasicFromJSONSchema } from './basic';
 
@@ -23,7 +23,7 @@ export type TypeFromJSONSchemaOrPreserve<T> = T extends boolean
 export type TypeFromJSONSchemaArray<
   T extends readonly JSONSchema7Definition[]
 > = {
-  [K in keyof T]: TypeFromJSONSchemaOrPreserve<T[K]>;
+  -readonly [K in keyof T]: TypeFromJSONSchemaOrPreserve<T[K]>;
 };
 
 export type TypeFromJSONSchemaObjectProperties<

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profusion/json-schema-to-typescript-definitions",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Automatic TypeScript definitions from JSON Schema7 (no code generation!)",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",


### PR DESCRIPTION
Some structures such as arrays and objects were not readonly and thus
were failing usage with plain JSONSchema7 types.

Add extensive tests to catch such errors.